### PR TITLE
reorder comments to match field

### DIFF
--- a/av/av.go
+++ b/av/av.go
@@ -179,8 +179,8 @@ type CodecData interface {
 
 type VideoCodecData interface {
 	CodecData
-	Width() int // Video height
-	Height() int // Video width
+	Width() int // Video width
+	Height() int // Video height
 }
 
 type AudioCodecData interface {


### PR DESCRIPTION
when studying the code, I found that the comments for width/height were not matching the field. 